### PR TITLE
Fix typo in bot.on_subscribed

### DIFF
--- a/aioviber/bot.py
+++ b/aioviber/bot.py
@@ -232,7 +232,7 @@ class Bot:
 
     def on_subscribed(self):
         def decorator(coro):
-            assert aio.iscoroutine(coro), 'function should be coroutine'
+            assert aio.iscoroutinefunction(coro), 'function should be coroutine'
 
             self._events_callbacks[EventType.SUBSCRIBED] = coro
             return coro


### PR DESCRIPTION
Without this fix, on_subscribed decorator will always complain `function should be coroutine`